### PR TITLE
Cope with attributes with spaces in their values

### DIFF
--- a/cssify.py
+++ b/cssify.py
@@ -69,6 +69,8 @@ def cssify(xpath):
     'a.multiple.classes'
     >>> cssify('//a[@href="bleh"]')
     'a[href=bleh]'
+    >>> cssify('//a[@href="bleh bar"]')
+    'a[href="bleh bar"]'
     >>> cssify('//a[@href="/bleh"]')
     'a[href=/bleh]'
     >>> cssify('//a[@class="class-bleh"]')
@@ -113,6 +115,8 @@ def cssify(xpath):
             elif match['mattr'] in ["text()", "."]:
                 attr = ":contains(^%s$)" % match['mvalue']
             elif match['mattr']:
+                if match["mvalue"].find(" ")!=-1:
+                    match["mvalue"] = "\"%s\""%match["mvalue"]
                 attr = "[%s=%s]" % (match['mattr'].replace("@", ""),
                                     match['mvalue'])
         elif match['contained']:


### PR DESCRIPTION
If you're trying to match an attribute whose value has a space in the name, you need to wrap in with quotes. They're omittable for values without spaces, but not for ones with them!
