### PR TITLE
Update cssify.py

### DIFF
--- a/cssify/cssify.py
+++ b/cssify/cssify.py
@@ -21,7 +21,7 @@ validation_re = (
         "|"
           "(?P<contained>contains\((?P<cattr>@?%(attribute)s,\s*[\"\'](?P<cvalue>%(value)s)[\"\']\))" # [contains(text(), "bleh")] or [contains(@id, "bleh")]
         ")\])?"
-        "(\[(?P<nth>\d)\])?"
+        "(\[(?P<nth>(\d)*)\])?"
       ")"
     ")" % sub_regexes
 )


### PR DESCRIPTION
It wasn't working for xpaths with more than one digits of value for example "//*[@id="tab-custom-1"]/div/p[10]", it was working perfactly for "//*[@id="tab-custom-1"]/div/p[1]"

I just modified the regex a little. (used quantifier)